### PR TITLE
Updated X_ITE URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ If using X_ITE:
 ```html
 <head>
    <script src="https://d3js.org/d3.v7.min.js"></script>
-   <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+   <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
    <script src="https://raw.githack.com/jamesleesaunders/d3-x3d/master/dist/d3-x3d.js"></script>
 </head>
 ```

--- a/examples/X_ITE/chart/AreaChartMultiSeries.html
+++ b/examples/X_ITE/chart/AreaChartMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Area Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/AreaChartMultiSeries2.html
+++ b/examples/X_ITE/chart/AreaChartMultiSeries2.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Area Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/BarChartMultiSeries.html
+++ b/examples/X_ITE/chart/BarChartMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Bar Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/BarChartVertical.html
+++ b/examples/X_ITE/chart/BarChartVertical.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Vertical Bar Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/BubbleChart.html
+++ b/examples/X_ITE/chart/BubbleChart.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Bubble Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/CrosshairPlot.html
+++ b/examples/X_ITE/chart/CrosshairPlot.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Crosshair Plot Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/DonutChart.html
+++ b/examples/X_ITE/chart/DonutChart.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Donut Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/HeatMap.html
+++ b/examples/X_ITE/chart/HeatMap.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Bar Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/ParticlePlot.html
+++ b/examples/X_ITE/chart/ParticlePlot.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Particle Plot Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/RibbonChartMultiSeries.html
+++ b/examples/X_ITE/chart/RibbonChartMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Ribbon Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/ScatterPlot.html
+++ b/examples/X_ITE/chart/ScatterPlot.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Scatter Plot Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/SpotPlot.html
+++ b/examples/X_ITE/chart/SpotPlot.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Spot Plot Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/SurfacePlot.html
+++ b/examples/X_ITE/chart/SurfacePlot.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Surface Plot Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/VectorFieldChart.html
+++ b/examples/X_ITE/chart/VectorFieldChart.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Vector Field Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/chart/VolumeSliceChart.html
+++ b/examples/X_ITE/chart/VolumeSliceChart.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Volume Slice Chart Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/Area.html
+++ b/examples/X_ITE/component/Area.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Area Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/AreaMultiSeries.html
+++ b/examples/X_ITE/component/AreaMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Area Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/BarsMultiSeries.html
+++ b/examples/X_ITE/component/BarsMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Bars Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/Bubbles.html
+++ b/examples/X_ITE/component/Bubbles.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Bubbles Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/BubblesMultiSeries.html
+++ b/examples/X_ITE/component/BubblesMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Bubbles Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/Crosshair.html
+++ b/examples/X_ITE/component/Crosshair.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Crosshair Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/HeatMap.html
+++ b/examples/X_ITE/component/HeatMap.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Bubbles Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/IntersectPlanes.html
+++ b/examples/X_ITE/component/IntersectPlanes.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Bubbles Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/Particles.html
+++ b/examples/X_ITE/component/Particles.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Particles Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/RibbonMultiSeries.html
+++ b/examples/X_ITE/component/RibbonMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Ribbon Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/Showcase.html
+++ b/examples/X_ITE/component/Showcase.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Component Showcase</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/SpotsMultiSeries.html
+++ b/examples/X_ITE/component/SpotsMultiSeries.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Multi Series Spots Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/X_ITE/component/Surface.html
+++ b/examples/X_ITE/component/Surface.html
@@ -4,7 +4,7 @@
   <head>
     <title>d3-x3d : 3D Surface Area Component Example</title>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <script src="https://create3000.github.io/code/x_ite/latest/x_ite.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.js"></script>
     <script src="../../../dist/d3-x3d.js"></script>
   </head>
 

--- a/examples/scratch/Torus.html
+++ b/examples/scratch/Torus.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8"/>
-  <script src="https://create3000.github.io/code/x_ite/latest/x_ite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.min.js"></script>
 </head>
 <body>
 

--- a/examples/scratch/Torus3.html
+++ b/examples/scratch/Torus3.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8"/>
-  <script src="https://create3000.github.io/code/x_ite/latest/x_ite.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/x_ite@latest/dist/x_ite.min.js"></script>
 </head>
 <body>
 


### PR DESCRIPTION
I have updated all X_ITE URLs to use the jsDeliver CDN, as jsDeliver has many advantages over serving files from GitHub pages. 

The X_ITE website will no longer list the https://create3000.github.io/code/... URL, although this URL will be kept alive and will receive further updates.

Best regards,
Holger